### PR TITLE
Renamed MIDDLEWARE_CLASSES to MIDDLEWARE

### DIFF
--- a/mitxpro_core/settings/common.py
+++ b/mitxpro_core/settings/common.py
@@ -23,6 +23,6 @@ def plugin_settings(settings):
     ]
     settings.MITXPRO_CORE_REDIRECT_DENY_RE_LIST = []
 
-    settings.MIDDLEWARE_CLASSES.extend(
+    settings.MIDDLEWARE.extend(
         ["mitxpro_core.middleware.RedirectAnonymousUsersToLoginMiddleware"]
     )

--- a/mitxpro_core/settings/test.py
+++ b/mitxpro_core/settings/test.py
@@ -24,7 +24,7 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
     ]
     settings.MITXPRO_CORE_REDIRECT_DENY_RE_LIST = []
 
-    settings.MIDDLEWARE_CLASSES = [
+    settings.MIDDLEWARE = [
         "mitxpro_core.middleware.RedirectAnonymousUsersToLoginMiddleware"
     ]
 


### PR DESCRIPTION
The xPRO juniper build is failing with the following error:
```
File \"/edx/app/edxapp/edx-platform/openedx/core/djangoapps/plugins/plugin_settings.py\", line 16, in add_plugins", "    settings_func(settings_module)", "  File \"/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/mitxpro_core/settings/common.py\", line 26, in plugin_settings", "    settings.MIDDLEWARE_CLASSES.extend(", "AttributeError: module 'lms.envs.common' has no attribute 'MIDDLEWARE_CLASSES'"], "stdout": "", "stdout_lines": []}
```
After looking at the openedx changes from [ironwood](https://github.com/edx/edx-platform/blob/open-release/ironwood.master/lms/envs/common.py#L1228) to [juniper](https://github.com/edx/edx-platform/blob/open-release/juniper.master/lms/envs/common.py#L1484), I noticed the `MIDDLEWARE_CLASSES` has be renamed to `MIDDLEWARE`.

This PR renames that value in the two files it's referenced.